### PR TITLE
Fix: Center footer address

### DIFF
--- a/source/_partials/footer.blade.php
+++ b/source/_partials/footer.blade.php
@@ -71,7 +71,7 @@
 
 </div>
 </div>
-<div class="bg-grey-lightest text-grey-dark p-8 leading-normal">
+<div class="bg-grey-lightest text-grey-dark p-8 leading-normal text-center">
   <p>Die Code+Design Initiative e.V. ist ein gemeinnütziger Verein zur Berufs- und Studienorientierung im Bereich Informatik und Design.</p>
 Vereinsregister VR 35667 B | Code+Design Initiative e.V. c/o CODE Education GmbH – Rheinsberger Straße 76/77, Berlin
 </div>


### PR DESCRIPTION
Added the class "text-center" in order to center the whole text inside the grey box in the footer.