### PR TITLE
Fix the invisible button on small devices

### DIFF
--- a/source/blog.blade.php
+++ b/source/blog.blade.php
@@ -50,7 +50,7 @@ pagination:
 					<div class="text-4xl back md:ml-4 mt-4 md:mt-0"><a class="no-underline text-black" href="{{$blog->getUrl()}}">{{$blog->caption}} </a></div>
 					<div class="text-2md mb-4 back md:ml-4 mt-4 md:mt-0"><small class="text-grey">{{$blog->author}} | {{ $blog->published_at}}</small></div>
                     <p class="text-lg mb-4 leading-normal md:ml-4 mt-4 md:mt-0">{{$blog->lead}}</p>
-					<div class="hidden md:block md:ml-4 mt-4 md:mt-0">
+					<div class="md:block md:ml-4 mt-4 md:mt-0">
 					  @component('_components.blog-button')
 						@slot('colorback')
 						purple


### PR DESCRIPTION
On small mobile devices < 7'' the "Mehr dazu lesen ..."-Button disappeared. 