### PR TITLE
Change: Routes to münchen camp

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -30,26 +30,26 @@
 /video/youtuber-ffm     https://www.youtube.com/watch?v=0U2EhyTTQMM
 /video/koeln-17         https://www.youtube.com/watch?v=4gQ6fqpkyZk
 /video/k%C3%B6ln-17     https://www.youtube.com/watch?v=4gQ6fqpkyZk
+/video/berlin-1710      https://youtu.be/nkQoinzvCv8
 
 # ambassador
 /botschafter-bewerbung  https://goo.gl/forms/wSxYfXEnpnCC14pI3
 /ich-bin-botschafterin  https://goo.gl/forms/wSxYfXEnpnCC14pI3
 
 #camp tools
-/ichkann                  https://airtable.com/shrCxM9zC7hOo9U4T
-/kompetenzen              https://airtable.com/shrwtNPgZxn4CbosV
-/aenderungen              https://airtable.com/shrfT52mf8tl9m9q0
-/feedback                 https://airtable.com/shrtLQrNyQuqdqipT
-/gruppen                  https://airtable.com/shrd4AMCnRYBgeQFf
-/gruppeninfos             https://airtable.com/shrAD805WRrtrEeCw
+/ichkann                  https://airtable.com/shrr3SSZgo38Mfen1
+/kompetenzen              https://airtable.com/shrLWAlbT4O62yQa1
+/feedback                 https://airtable.com/shrqwod7mKCA5hb0k
+/unseregruppe             https://airtable.com/shrd4AMCnRYBgeQFf
+/gruppen                  https://airtable.com/shrYQyA4jyy6qu7p4
 /link                     https://hackmd.io/s/S10XMocL7
-/schwarzesbrett         https://docs.google.com/presentation/d/1cPOcP_rassnVI-6XY3A6nCPT46EXojdwdDxQC3VY2ws/edit#slide=id.g3fdf53cfac_0_0
-/warmup                 https://hackmd.io/s/HJxnPEhg8X#
-/hackpad                       https://hackmd.io/s/BJS5dEyLX#
+/schwarzesbrett           https://docs.google.com/presentation/d/1tZ1JuPpsHIca9_1MUEzqXDsNeAhGsNCpYIBkfje-xgU/edit#slide=id.g3fdf53cfac_0_47
+/warmup                   https://hackmd.io/s/HJxnPEhg8X#
 
 # other
 /blogs                  /blog
-/tools                  https://docs.google.com/document/d/1TvD8SAAfE6PgBgcxp3OzTDcEI69_fFNBCf2aoisjJxc/edit?usp=sharing
+/tools                  https://github.com/CodeDesignInitiative/awesome-coding-and-designing
 /chat  			 https://join.slack.com/t/code-design-camp/shared_invite/enQtMjk3MTg0NzQ2MjI5LWVlOGJjYzNjMDZmYzRiYmYwMzc3ZmQ5ZTQyMTM1YWEzZmVjMjAzNGM3NDE4MjBlZDE0OThiZTZjMzkxNDk2ZmQ
 /sei-camp-reporter      https://airtable.com/shrkkPRr2dVsm9Ogk
-/2                   https://airtable.com/shrsv1gXqfFVJt1AR
+/twitter                https://twitter.com/codeunddesign
+/instagram              https://www.instagram.com/codeunddesign/


### PR DESCRIPTION
Removed Route: /aenderungen, /2
Added:
social media, berlin1710 video and routes for current camp muenchen